### PR TITLE
TypeScript: missing properties in MutationOpts (fix for #750)

### DIFF
--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -27,6 +27,8 @@ import ApolloClient, {
   FetchMoreQueryOptions,
   SubscribeToMoreOptions,
 } from 'apollo-client';
+import { PureQueryOptions } from 'apollo-client/core/types';
+import { MutationUpdaterFn } from 'apollo-client/core/watchQueryOptions';
 
 import {
   ExecutionResult,
@@ -39,6 +41,8 @@ export declare interface MutationOpts {
   variables?: Object;
   optimisticResponse?: Object;
   updateQueries?: MutationQueryReducersMap;
+  refetchQueries?: string[] | PureQueryOptions[];
+  update?: MutationUpdaterFn;
 }
 
 export declare interface QueryOpts {


### PR DESCRIPTION
These are based on definitions from [apollo-client](https://github.com/apollographql/apollo-client/blob/ca17c34dc6f6da3eba682eadd166f82c3913692e/src/core/watchQueryOptions.ts#L143).

- [x] Make sure all tests and linter rules pass

